### PR TITLE
Update templates to use https whenever loading the discovery doc.

### DIFF
--- a/GcmEndpoints/root/src/webapp/index.html.ftl
+++ b/GcmEndpoints/root/src/webapp/index.html.ftl
@@ -101,8 +101,13 @@
     function init() {
       var apiName = 'messaging'
       var apiVersion = 'v1'
-      // set the apiRoot to work on a deployed app and locally
-      var apiRoot = '//' + window.location.host + '/_ah/api';
+      var apiRoot = 'https://' + window.location.host + '/_ah/api';
+      if (window.location.hostname == 'localhost'
+          || window.location.hostname == '127.0.0.1'
+          || ((window.location.port != "") && (window.location.port > 999))) {
+            // We're probably running against the DevAppServer
+            apiRoot = 'http://' + window.location.host + '/_ah/api';
+      }
       var callback = function() {
         enableClick();
       }

--- a/HelloEndpoints/root/src/webapp/index.html.ftl
+++ b/HelloEndpoints/root/src/webapp/index.html.ftl
@@ -92,7 +92,13 @@
     function init() {
       var apiName = 'myApi';
       var apiVersion = 'v1';
-      var apiRoot = '//' + window.location.host + '/_ah/api';
+      var apiRoot = 'https://' + window.location.host + '/_ah/api';
+      if (window.location.hostname == 'localhost'
+          || window.location.hostname == '127.0.0.1'
+          || ((window.location.port != "") && (window.location.port > 999))) {
+            // We're probably running against the DevAppServer
+            apiRoot = 'http://' + window.location.host + '/_ah/api';
+      }
       var callback = function() {
         enableClick();
       }


### PR DESCRIPTION
Update templates to use https whenever loading the discovery doc. HTTPS is always required (even when the host page is loaded using http), unless running against the devappserver.

It's not imperative that we update the Studio templates with this change right now.
