### PR TITLE
Should this really be a static call?

### DIFF
--- a/HelloEndpoints/README.md
+++ b/HelloEndpoints/README.md
@@ -41,7 +41,7 @@ To start sending requests to the added Cloud Endpoints backend API, you can use 
 
 ```java
 class EndpointsAsyncTask extends AsyncTask<Pair<Context, String>, Void, String> {
-    private static MyApi myApiService = null;
+    private MyApi myApiService = null;
     private Context context;
 
     @Override


### PR DESCRIPTION
Compile fails when doing a "copy/paste" example. Solved by removing the static modifier. 
