### PR TITLE
Add the localhost's IP address for Genymotion emulators

### DIFF
--- a/HelloEndpoints/README.md
+++ b/HelloEndpoints/README.md
@@ -51,7 +51,7 @@ class EndpointsAsyncTask extends AsyncTask<Pair<Context, String>, Void, String> 
                     new AndroidJsonFactory(), null)
                 // options for running against local devappserver
                 // - 10.0.2.2 is localhost's IP address in Android emulator
-                // - 10.0.3.2 is localhost's IP address for Genymotion emulator
+                // - 10.0.3.2 is localhost's IP address in Genymotion emulator
                 // - turn off compression when running against local devappserver
                 .setRootUrl("http://10.0.2.2:8080/_ah/api/")
                 .setGoogleClientRequestInitializer(new GoogleClientRequestInitializer() {

--- a/HelloEndpoints/README.md
+++ b/HelloEndpoints/README.md
@@ -51,6 +51,7 @@ class EndpointsAsyncTask extends AsyncTask<Pair<Context, String>, Void, String> 
                     new AndroidJsonFactory(), null)
                 // options for running against local devappserver
                 // - 10.0.2.2 is localhost's IP address in Android emulator
+                // - 10.0.3.2 is localhost's IP address for Genymotion emulator
                 // - turn off compression when running against local devappserver
                 .setRootUrl("http://10.0.2.2:8080/_ah/api/")
                 .setGoogleClientRequestInitializer(new GoogleClientRequestInitializer() {


### PR DESCRIPTION
Updated the README.md for HelloEndPoints to include the localhost's IP address for Genymotion emulators in EndpointsAsyncTask to make it easier for devs.